### PR TITLE
Config heroku

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
       DB_NAME: postgres
       DB_NAME_DEV: postgres
       DB_NAME_TEST: postgres
+      DB_EXTRA_SSL: false
     # Docker Hub image that `container-job` executes in
     container: node:10.18-jessie
 

--- a/config/index.ts
+++ b/config/index.ts
@@ -39,8 +39,10 @@ const config: IConfig = {
       database: process.env.DB_NAME || 'database',
       username: process.env.DB_USERNAME || 'username',
       password: process.env.DB_PASSWORD || 'password',
-      ssl: {
-        rejectUnauthorized: false
+      extra: {
+        ssl: {
+          rejectUnauthorized: false
+        }
       },
       type: 'postgres',
       logging: logger.info

--- a/config/index.ts
+++ b/config/index.ts
@@ -39,7 +39,7 @@ const config: IConfig = {
       database: process.env.DB_NAME || 'database',
       username: process.env.DB_USERNAME || 'username',
       password: process.env.DB_PASSWORD || 'password',
-      extra: {
+      extra: process.env.DB_EXTRA_SSL || {
         ssl: {
           rejectUnauthorized: false
         }

--- a/config/index.ts
+++ b/config/index.ts
@@ -39,6 +39,9 @@ const config: IConfig = {
       database: process.env.DB_NAME || 'database',
       username: process.env.DB_USERNAME || 'username',
       password: process.env.DB_PASSWORD || 'password',
+      ssl: {
+        rejectUnauthorized: false
+      },
       type: 'postgres',
       logging: logger.info
     },

--- a/types/config/index.d.ts
+++ b/types/config/index.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 type ENV_VAR = string | undefined;
 
 type dialect = 'postgres' | 'mysql' | 'sqlite' | 'mssql' | 'oracle';
@@ -14,8 +15,8 @@ export interface IConfig {
       database: string;
       username: string;
       password: string;
-      ssl: object;
       type: dialect;
+      extra: any;
       logging: boolean;
     };
     api: {

--- a/types/config/index.d.ts
+++ b/types/config/index.d.ts
@@ -14,6 +14,7 @@ export interface IConfig {
       database: string;
       username: string;
       password: string;
+      ssl: object;
       type: dialect;
       logging: boolean;
     };


### PR DESCRIPTION
## Summary

feat: add ssl config for use a heroku postgres DB

## Known Issues

Error: when using the db that heroku generated, it did not work due to the SSL.
Fix: add ssl option in connection config.

## Trello Card

https://trello.com/c/GfbD37s4

## Heroku
link: [https://fm-typescript.herokuapp.com/](url)